### PR TITLE
Code to prevent "DROP TABLE" from being entered

### DIFF
--- a/lib/live_sql.rb
+++ b/lib/live_sql.rb
@@ -106,6 +106,7 @@ class LiveSQL
   end
 
   def query_db(string)
+    return if string =~ /drop/i
     @db.execute(<<-SQL)
       #{string}
       LIMIT 30


### PR DESCRIPTION
This is a quick fix to prevent `DROP TABLE` commands inadvertently typed by the user.
Awesome that you made this Fred!
